### PR TITLE
Fixing collectd_plugins_multi variable type

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ collectd_global:
  - { directive: "AutoLoadPlugin false" }
 
 collectd_plugins: "none"
-collectd_plugins_multi: "none"
+collectd_plugins_multi: {}
 
 collectd_conf_rh: "/etc/collectd.conf"
 collectd_conf_deb: "/etc/collectd/collectd.conf"


### PR DESCRIPTION
The variable `collectd_plugins_multi` should be empty dict by default and not a string.