### PR TITLE
Add configuration option to include other configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ collectd_global:
 collectd_plugins: "none"
 collectd_plugins_multi: "none"
 
+collectd_include_other_confs: false
+
 collectd_conf_rh: "/etc/collectd.conf"
 collectd_conf_deb: "/etc/collectd/collectd.conf"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ collectd_global:
 collectd_plugins: "none"
 collectd_plugins_multi: {}
 
+collectd_include_other_confs: false
+
 collectd_conf_rh: "/etc/collectd.conf"
 collectd_conf_deb: "/etc/collectd/collectd.conf"
 

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -35,8 +35,16 @@ LoadPlugin {{ key }}
 {% endif %}
 
 {% if ansible_os_family == "RedHat" %}
+{% if collectd_include_other_confs %}
+Include "{{ collectd_include_rh }}/*.include.conf"
+{% else %}
 #Include "{{ collectd_include_rh }}/*.include.conf"
 {% endif %}
+{% endif %}
 {% if ansible_os_family == "Debian" %}
+{% if collectd_include_other_confs %}
+Include "{{ collectd_include_rh }}/*.include.conf"
+{% else %}
 #Include "{{ collectd_include_deb }}/*.include.conf"
+{% endif %}
 {% endif %}


### PR DESCRIPTION
Providing sophisticated configuration for eg. GenericJMX plugin within
collectd.conf is tedious task. It would be easier if there would be a
way to include other configuration files. This way GenericJMX
configuration can be kept in a separate template file, then copied.

This patch introduces collectd_include_other_confs boolean parameter that
enable 'Include' directive in collectd.conf file when set to 'true'.

This makes CollectD configuration management easier.